### PR TITLE
オススメ度のdivision by zeroを回避

### DIFF
--- a/python-flask/app/calc_info.py
+++ b/python-flask/app/calc_info.py
@@ -89,7 +89,10 @@ def calc_recommend_score(result_json):
     M = 100 #設定したい最大値
     m = 50 #設定したい最小値
     for s in score_list:
-        norm_score = ((s - min_score)*(M - m) / (max_score - min_score)) + m
+        try:
+            norm_score = ((s - min_score)*(M - m) / (max_score - min_score)) + m
+        except:
+            norm_score = 100 #maxとminが同じ場合は全て100
         norm_score_list.append(norm_score)
     
     for i, n_s in zip(index_list, norm_score_list):


### PR DESCRIPTION
オススメ度の最大値と最小値が同じ場合 or データが1つしかない場合 は0割でエラーになっていたので、
その場合は全て同じオススメ度(つまり100)にしました。