### PR TITLE
MySQLの認証方式を変更

### DIFF
--- a/mysql/initdb.d/init.sql
+++ b/mysql/initdb.d/init.sql
@@ -1,3 +1,5 @@
+ALTER USER 'root' IDENTIFIED WITH mysql_native_password BY 'pass';
+
 DROP DATABASE IF EXISTS reskima_db;
 CREATE DATABASE reskima_db;
 


### PR DESCRIPTION
SQLAlchemyが`caching_sha2_password`の認証方式に対応していないため，`mysql_native_password`を利用するようにした
