### PR TITLE
Front: チュートリアルカードの受け入れ準備 / 画像表示時間の短縮

### DIFF
--- a/react/src/app-components/Home.js
+++ b/react/src/app-components/Home.js
@@ -38,6 +38,7 @@ function Home(props) {
     // view を抱える。背景操作の都合で mode は上位コンポーネント App に持たせる
     const [view, setView] = useState("Selection")
     const [userId, setUserId] = useState(produceId())
+    const [tutorialIsOn,setTutorialIsOn] = useState(true)
 
     // 招待URLの処理
     const location = useLocation()
@@ -107,12 +108,14 @@ function Home(props) {
                             inviteUrl={inviteUrl}
                             callInviteUrl={callInviteUrl}
                             paramsForSearch={paramsForSearch}
+                            tutorialIsOn={tutorialIsOn}
                         />
                         : view === "KeepList" ?
                             <KeepList
                                 mode={props.mode}
                                 userId={userId}
                                 groupId={groupId}
+                                setTutorialIsOn={setTutorialIsOn}
                             />
                             :
                             <Setting
@@ -125,6 +128,7 @@ function Home(props) {
                                 callInviteUrl={callInviteUrl}
                                 paramsForSearch={paramsForSearch}
                                 setParamsForSearch={setParamsForSearch}
+                                setTutorialIsOn={setTutorialIsOn}
                             />}
                 </div>
             </div>

--- a/react/src/app-components/home-components/Selection.js
+++ b/react/src/app-components/home-components/Selection.js
@@ -4,8 +4,6 @@ import "./../../css/Selection.css"
 import axios from "axios"
 import { useEffect, useState } from "react"
 // 他のファイルからインポート
-import ButtonToInvite from "./selection-components/ButtonToInvite"
-import ButtonToShowComment from "./selection-components/ButtonToShowComment"
 import RestaurantInformation from './selection-components/RestaurantInformation'
 import RestaurantInformationDeck from './selection-components/RestaurantInformationDeck'
 import noImageIcon from "./../../img/no_image.png"

--- a/react/src/app-components/home-components/Selection.js
+++ b/react/src/app-components/home-components/Selection.js
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react"
 import RestaurantInformation from './selection-components/RestaurantInformation'
 import RestaurantInformationDeck from './selection-components/RestaurantInformationDeck'
 import noImageIcon from "./../../img/no_image.png"
+import tutorialDataList from "./../../samples/tutorialData.json"
 
 const initDataList = [{
   "Name": "Loading...",
@@ -31,10 +32,15 @@ var wrapperStyle = {
  スワイプでお店を選ぶコンポーネント
  */
 function Selection(props) {
-  const [dataLists, setDataLists] = useState({
-    "topDataList": initDataList,
-    "standbyDataList":null,
-  })
+  const [dataLists, setDataLists] = useState(
+        props.tutorialIsOn?{ 
+            "topDataList": tutorialDataList.slice(0,2),
+            "standbyDataList": tutorialDataList.slice(2),
+        }:{
+            "topDataList": initDataList,
+            "standbyDataList": null,
+        }
+  )
   let isLoading = false
   let hiddenDataList = null
 
@@ -43,7 +49,6 @@ function Selection(props) {
     if (isLoading) return;
     isLoading = true
     
-
     // ユーザID を設定
     let userId = newUserId
     if (newUserId === undefined || newUserId === null || newUserId.length === 0) {
@@ -124,13 +129,18 @@ function Selection(props) {
   }
 
   useEffect(() => {
-    getInfo()
+      if(props.tutorialIsOn===false){
+          getInfo(null,null,"init",null)
+      }
     // Mount 時にだけ呼び出す
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // APIにキープ・リジェクトを送信する
   const sendFeeling = (feeling, restaurant_id) => {
+    // tutorial card は送らない
+    if(restaurant_id.indexOf('tutorial')!==-1) return;
+
     axios.post('/api/feeling', {
       params: {
         user_id: props.userId,

--- a/react/src/app-components/home-components/Setting.js
+++ b/react/src/app-components/home-components/Setting.js
@@ -35,6 +35,9 @@ function Setting(props) {
         // モード設定
         props.setMode(newMode)
 
+        //　チュートリアルをオンにする
+        props.setTutorialIsOn(true)
+
         // Selection に移る
         props.setView("Selection")
     }

--- a/react/src/app-components/home-components/Tutorial.js
+++ b/react/src/app-components/home-components/Tutorial.js
@@ -1,0 +1,22 @@
+import React from 'react'
+// 他のパッケージからインポート
+import { Box, Card, CardContent } from '@material-ui/core'
+
+function Tutorial(props){
+    return(
+        <Box 
+            style={{
+                height:'100%',
+                width:'100%',
+                backgroundColor: 'rgba(0,0,0,.4)',
+                position: 'absolute'
+            }}
+        >
+            <Card>
+                <CardContent>
+                </ CardContent>
+            </Card>
+        </Box>
+    )
+}
+export default Tutorial

--- a/react/src/app-components/home-components/selection-components/RestaurantInformation.js
+++ b/react/src/app-components/home-components/selection-components/RestaurantInformation.js
@@ -128,7 +128,10 @@ function RestaurantInformation(props) {
     }
     // コメントボタンの描画
     const renderButtonToShowComment = () =>{
-        const ok = props.data.Restaurant_id !== 'init' && props.data.Restaurant_id !== 'empty'
+        const ok = props.data.Restaurant_id !== 'init' 
+            && props.data.Restaurant_id !== 'empty' 
+            && props.data.Restaurant_id.indexOf('tutorial')==-1
+
         return (
             ok
             ?<ButtonToShowComment data={props.data} />

--- a/react/src/app-components/home-components/selection-components/RestaurantInformation.js
+++ b/react/src/app-components/home-components/selection-components/RestaurantInformation.js
@@ -7,9 +7,10 @@ import { Chip } from '@material-ui/core'
 import Typography from '@material-ui/core/Typography'
 import Box from '@material-ui/core/Box'
 // 他ファイルからインポート
-import Buttons from './Buttons'
-import ButtonToShowComment from './ButtonToShowComment'
-import ButtonToInvite from './ButtonToInvite'
+import Buttons from './restaurant-information-components/Buttons'
+import ButtonToShowComment from './restaurant-information-components/ButtonToShowComment'
+import ButtonToInvite from './restaurant-information-components/ButtonToInvite'
+import ImageArea from './restaurant-information-components/ImageArea'
 
 const useStyles = makeStyles((theme) => ({
     RestaurantInformation :{
@@ -46,65 +47,8 @@ const useStyles = makeStyles((theme) => ({
         display: 'inline-block',
         margin: '0',
     },
-    imageContainer :{
-        position: 'absolute',
-        width: '100%',
-        height: '100%',
-        backgroundColor: 'transparent',
-    },
-    image :{
-        height: '100%',
-        objectFit: 'cover',
-        backgroundColor: 'transparent',
-        webkitUserSelect: 'none',
-        mozUserSelect: 'none',
-        MsUserSelect: 'none',
-        userSelect: 'none',
-        pointerEvents: 'none',
-        willChange: 'opacity',
-        position: 'absolute',
-    },
-    imageFilter :{
-        width: '100%',
-        height: '100%',
-        position: 'absolute',
-        background: `linear-gradient( rgba(0, 0, 0, 0), rgba(0, 0, 0, 0) 70%,rgba(0, 0, 0, 1) 85%, rgba(0, 0, 0, 1))`,
-    },
 }));
 
-function Bar(props){
-    const background=props.isSelected===true?'rgba(255,255,255,1)':'rgba(0,0,0,.4)'
-    return (
-        <Box
-            height='100%'
-            width='100%'
-            boxShadow='0px 4px 4px rgba(0, 0, 0, 0.75)'
-            border='2px solid gray'
-            borderRadius='10%'
-            margin='1%'
-            cursor='pointer'
-            css={{background:background}}
-            onClick={props.onClick}
-        />
-    )
-}
-
-function Bars(props){
-    return(
-        <Box 
-            width='80%'
-            height='1%'
-            top='5%'
-            left='10%'
-            display='flex'
-            position='absolute'
-        >
-            {props.Images.map( (image,i) =>{
-                return <Bar isSelected={i===props.index} onClick={()=>{ props.setIndex(i)}} />
-            })} 
-        </Box>
-    )
-}
 
 const StyledChipRating = withStyles({
     root: {
@@ -129,36 +73,15 @@ function RestaurantInformation(props) {
     const classes = useStyles(props)
     const space = <span className={classes.space}>　</span>
 
-    const [index, setIndex] = useState(0)
-
-    useEffect(() => {
-        const currentIndex = index
-        const t = setInterval(
-            () => {
-                if(currentIndex!==undefined && currentIndex===index){
-                    setIndex(state => (state + 1) % props.data.Images.length)
-                }
-            }
-        , 5000)
-        return ()=>{clearInterval(t)}
-    },[index])
-
-    // お店画像の描画
-    const renderImages = (restaurant_id) =>{
-        return(
-            <div className={classes.imageContainer}>
-                {props.data.Images.map( (image,i)=>{
-                    return <img 
-                        className={classes.image}
-                        id={restaurant_id+'-image'+i}
-                        alt={'restaurant-image'+i}
-                        src={image} 
-                        style={{opacity: index===i?1:0, transition:'0.5s',}}
-                    />
-                  })}
-            </div>
-        )
-    }
+   // 画像の描画
+   const renderImageArea = (data) =>{
+       return(
+           <ImageArea 
+                Images={data.Images}
+                restaurant_id={data.Restaurant_id}
+           />
+       )
+   }
 
     // お店情報の描画
     const isNotEmpty = (str) =>{
@@ -226,11 +149,9 @@ function RestaurantInformation(props) {
     return (
         <div className={classes.RestaurantInformation} style={props.wrapperStyle}>
             <Card variant="outlined" className={classes.cardRoot}>
-                {renderImages(props.data.restaurant_id)}
-                <div className={classes.imageFilter} />
+                {renderImageArea(props.data)}
                 {renderCardContent(props.data)}
                 {renderButtons()}
-                <Bars Images={props.data.Images} index={index} setIndex={setIndex}/>
                 {renderButtonToInvite()}
                 {renderButtonToShowComment()}
             </Card>

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/ButtonToInvite.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/ButtonToInvite.js
@@ -7,9 +7,8 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText';
 import DialogTitle from '@material-ui/core/DialogTitle'
 import { makeStyles,withStyles } from '@material-ui/core/styles'
-import { CopyToClipboard } from 'react-copy-to-clipboard'
 // 他ファイルからインポート
-import InviteIcon from './../../../icon/InviteIcon'
+import InviteIcon from './../../../../icon/InviteIcon'
 import InviteModal from './InviteModal'
 /*
 招待ボタン：押すと招待URLが表示される

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/ButtonToInvite.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/ButtonToInvite.js
@@ -17,7 +17,7 @@ import InviteModal from './InviteModal'
 const useStyles = makeStyles({
     ButtonToInviteContainer:{
         position: 'absolute',
-        top: '50%',
+        top: '40%',
         width: '100%',
         textAlign: 'right',
         pointerEvents: 'none',

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/ButtonToShowComment.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/ButtonToShowComment.js
@@ -6,7 +6,7 @@ import DialogTitle from '@material-ui/core/DialogTitle'
 import { DialogContent } from '@material-ui/core'
 import { makeStyles,withStyles } from '@material-ui/core/styles'
 // 他ファイルからインポート
-import CommentIcon from './../../../icon/CommentIcon'
+import CommentIcon from './../../../../icon/CommentIcon'
 import CommentModal from './CommentModal'
 
 /*

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/ButtonToShowComment.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/ButtonToShowComment.js
@@ -16,7 +16,7 @@ import CommentModal from './CommentModal'
 const useStyles = makeStyles({
     ButtonToShowCommentContainer:{
         position: 'absolute',
-        top: '60%',
+        top: '50%',
         width: '100%',
         textAlign: 'right',
         pointerEvents: 'none',

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/Buttons.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/Buttons.js
@@ -3,8 +3,8 @@ import { Grid } from "@material-ui/core"
 import { makeStyles,withStyles } from '@material-ui/core'
 
 // 他ファイルからインポート
-import CircleIcon from './../../../icon/CircleIcon.js'
-import CrossIcon from './../../../icon/CrossIcon.js'
+import CircleIcon from './../../../../icon/CircleIcon.js'
+import CrossIcon from '../../../../icon/CrossIcon.js'
 
 /* 
 ボタンをGridでまとめたもの

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/CommentModal.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/CommentModal.js
@@ -6,7 +6,7 @@ import Chip from '@material-ui/core/Chip';
 import { Box, Dialog, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
 import { Slide } from '@material-ui/core';
 // 他ファイルからインポート
-import { ReactComponent as CommentClose } from '../../../img/comment-close.svg';
+import { ReactComponent as CommentClose } from '../../../../img/comment-close.svg';
 
 // モーダルの遷移方法を規定する
 const Transition = React.forwardRef(function Transition(props, ref) {

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/ImageArea.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/ImageArea.js
@@ -1,0 +1,106 @@
+import React from 'react'
+// パッケージからインポート
+import { useState, useEffect } from 'react'
+import Box from '@material-ui/core/Box'
+
+function Bar(props){
+    const background=props.isSelected===true?'rgba(255,255,255,1)':'rgba(0,0,0,.4)'
+    return (
+        <Box
+            height='100%'
+            width='100%'
+            boxShadow='0px 4px 4px rgba(0, 0, 0, 0.75)'
+            border='2px solid gray'
+            borderRadius='10%'
+            margin='1%'
+            cursor='pointer'
+            css={{background:background}}
+            onClick={props.onClick}
+        />
+    )
+}
+
+function Bars(props){
+    return(
+        <Box 
+            width='80%'
+            height='1%'
+            top='5%'
+            left='10%'
+            display='flex'
+            position='absolute'
+        >
+            {props.Images.map( (image,i) =>{
+                return <Bar isSelected={i===props.index} onClick={()=>{ props.setIndex(i)}} />
+            })} 
+        </Box>
+    )
+}
+
+function RestaurantImage(props){
+    return(
+        <img 
+            id={props.restaurant_id+'-image'+props.i}
+            alt={'restaurant-image'+props.i}
+            src={props.image} 
+            style={
+                {
+                    opacity: props.isSelected?1:0, 
+                    transition:'0.5s',
+                    height: '100%',
+                    objectFit: 'cover',
+                    backgroundColor: 'transparent',
+                    webkitUserSelect: 'none',
+                    mozUserSelect: 'none',
+                    MsUserSelect: 'none',
+                    userSelect: 'none',
+                    pointerEvents: 'none',
+                    willChange: 'opacity',
+                    position: 'absolute',
+                }}
+        />
+    )
+}
+
+// バー付きの画像を表示する
+function ImageArea(props){
+    const [index, setIndex] = useState(0)
+
+    useEffect(() => {
+        const currentIndex = index
+        const t = setInterval(
+            () => {
+                if(currentIndex!==undefined && currentIndex===index){
+                    setIndex(state => (state + 1) % props.Images.length)
+                }
+            }
+        , 5000)
+        return ()=>{clearInterval(t)}
+    },[index])
+
+    return(
+        <Box>
+            <Box 
+                position='absolute'
+                width='100%'
+                height='100%'
+                backgroundColor='transparent'
+            >
+                {props.Images.map( (image,i)=>{
+                    return <RestaurantImage image={image} i={i} restaurant_id={props.restaurant_id} isSelected={index===i}/>
+                })}
+            </Box>
+            <Box
+                style={ {
+                    width:'100%',
+                    height:'100%',
+                    position:'absolute',
+                    background:`linear-gradient( rgba(0, 0, 0, 0), rgba(0, 0, 0, 0) 70%,rgba(0, 0, 0, 1) 85%, rgba(0, 0, 0, 1))`,
+                } }
+            >
+            </Box>
+            <Bars Images={props.Images} index={index} setIndex={setIndex}/>
+        </Box>
+    )
+}
+export default ImageArea

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/ImageArea.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/ImageArea.js
@@ -74,7 +74,7 @@ function ImageArea(props){
                     setIndex(state => (state + 1) % props.Images.length)
                 }
             }
-        , 5000)
+        , 2500)
         return ()=>{clearInterval(t)}
     },[index])
 

--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/InviteModal.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/InviteModal.js
@@ -9,8 +9,8 @@ import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { DialogContent, Typography } from '@material-ui/core'
 
 // 他ファイルからインポート
-import { ReactComponent as CopyBefore } from '../../../img/copy-before.svg'
-import { ReactComponent as CopyAfter } from '../../../img/copy-after.svg'
+import { ReactComponent as CopyBefore } from '../../../../img/copy-before.svg'
+import { ReactComponent as CopyAfter } from '../../../../img/copy-after.svg'
 
 const useStyles = makeStyles({
     CopyButton:{

--- a/react/src/samples/tutorialData.json
+++ b/react/src/samples/tutorialData.json
@@ -1,0 +1,30 @@
+[
+    {
+        "Restaurant_id": "tutorial-1",
+        "Name": "Tutorial 1",
+        "Images": [
+            ""
+        ]
+    },
+    {
+        "Restaurant_id": "tutorial-2",
+        "Name": "Tutorial 2",
+        "Images": [
+            ""
+        ]
+    },
+    {
+        "Restaurant_id": "tutorial-3",
+        "Name": "Tutorial 3",
+        "Images": [
+            ""
+        ]
+    },
+    {
+        "Restaurant_id": "tutorial-4",
+        "Name": "Tutorial 4",
+        "Images": [
+            ""
+        ]
+    }
+]


### PR DESCRIPTION
- スワイプの開始時チュートリアル用のカードを表示できるようにしました

  - KeepList の useEffect に props.setTutorialIsOn(false) を書き足すとKeepList から戻ってきた時チュートリアルがOFFになります

- 画像を映してから切り替えるまでの時間を 5s から 2.5s に短縮しました