### PR TITLE
Front: 招待リンクボタンのサイズ調整

### DIFF
--- a/react/src/app-components/home-components/selection-components/restaurant-information-components/InviteModal.js
+++ b/react/src/app-components/home-components/selection-components/restaurant-information-components/InviteModal.js
@@ -15,6 +15,7 @@ import { ReactComponent as CopyAfter } from '../../../../img/copy-after.svg'
 const useStyles = makeStyles({
     CopyButton:{
         width: '100%',
+        maxWidth: '40vh',
         border: 'none',
         padding: '0',
         backgroundColor: 'transparent',


### PR DESCRIPTION
https://github.com/seal-git/22zemi/issues/281 を受けて招待リンクコピーボタンの最大サイズを調整しました。

![スクリーンショット 2021-10-14 213933](https://user-images.githubusercontent.com/44494152/137319755-d4cbafb4-d03c-45ac-93f1-b16c643dd39f.png)