### PR TITLE
スレッドの重複回避

### DIFF
--- a/python-flask/app/README.md
+++ b/python-flask/app/README.md
@@ -28,3 +28,14 @@ list:
 		→ api_functions.py/get_restaurants_info()
 				⇄ calc_info.py
 
+config.py
+database_setting.py
+database_functions.py
+internal_info.py
+models.py
+internal_info.py
+recommend.py
+call_api.py
+api_functions.py
+calc_info.py
+

--- a/python-flask/app/database_setting.py
+++ b/python-flask/app/database_setting.py
@@ -60,6 +60,9 @@ class Group(Base):
     api_method = Column('api_method', String(50))  # 検索条件 # レコメンド
     price_average = Column('group_price', Float)  # レコメンド # 平均価格
     distance_average = Column('group_distance', Float)  # レコメンド # 平均距離
+    writable = Column('writable', Boolean, nullable=False,
+                      default=True)  # スレッドで検索している途中でリクエストが来たときのために，排他処理をする
+    wait_calc_priority = Column('wait_calc_priority', Boolean, nullable=False, default=False) # 優先度計算待ちのスレッドがあるかどうか。
     created_at = Column('created_at', Timestamp,
                         server_default=current_timestamp(), nullable=False)
     updated_at = Column('update_at', Timestamp, server_default=text(
@@ -124,8 +127,6 @@ class Belong(Base):
                                      server_default='0')  # レコメンド # レストランを受け取った数
     next_response = Column('next_response',
                            String(16000))  # 次のレスポンスをあらかじめ検索して新しい順に保持する
-    writable = Column('writable', Boolean, nullable=False,
-                      default=True)  # スレッドで検索している途中でリクエストが来たときのために，排他処理をする
     created_at = Column('created_at', Timestamp,
                         server_default=current_timestamp(), nullable=False)
     updated_at = Column('update_at', Timestamp, server_default=text(

--- a/python-flask/app/models.py
+++ b/python-flask/app/models.py
@@ -264,7 +264,9 @@ def http_info():
     if first_time_group_flg:
         # 裏でrecommendを走らせる
         ## 他のスレッドで更新中だったら何もしない
-        if fetch_belong.writable:
+        session = database_functions.get_db_session()
+        fetch_group = session.query(Group).filter(Group.id==group_id).one()
+        if fetch_group.writable:
             t = threading.Thread(target=thread_info,
                                  args=(group_id,
                                        user_id,
@@ -273,6 +275,7 @@ def http_info():
                                        ))
             t.start()
 
+        session.close()
     return response
 
 
@@ -292,20 +295,41 @@ def thread_info(group_id, user_id, fetch_belong, fetch_group):
     -------
 
     """
+    session = database_functions.get_db_session()
+    fetch_group = session.query(Group).filter(Group.id == group_id).one()
+    
+    # 他に待機中のスレッドがあれば、このスレッドは破棄
+    if fetch_group.wait_calc_priority:
+        session.close()
+        print("calc_priority_thread: dispose")
+        return
 
     ## 他のスレッドで更新中だったら待つ
-    if not fetch_belong.writable:
+    if not fetch_group.writable:
+    
+        fetch_group.wait_calc_priority = True
+        session.commit()
+
         result = False
-        session = database_functions.get_db_session()
         while not result:
-            print("waiting")
+            print("calc_priority_thread: waiting")
             time.sleep(1)
             session.commit()
-            result = session.query(Belong).filter(Belong.group == group_id,
-                                                  Belong.user == user_id).one().writable
-        session.close()
+            result = session.query(Group).filter(Group.id == group_id).one().writable
+        
+        fetch_group.wait_calc_priority = False
+        session.commit()
+    
+    # 店舗情報取得と優先度計算
+    fetch_group.writable = False
+    session.commit()
+
     _ = recommend.recommend_main(fetch_group, group_id, user_id)
-    print("thread end")
+
+    fetch_group.writable = True
+    session.commit()
+    session.close()
+    print("calc_priority_thread: end")
     return
 
 


### PR DESCRIPTION
優先度計算のスレッドが立ちすぎないようにしました。

ひとつスレッドが実行中のときに、ユーザがスワイプを続けていくと、重複したスレッドが複数立ってしまう問題がありました。それらは、前のスレッドが終わるまで待っているので、ユーザがスワイプし終わってからたくさんの処理が回ってしまいます。

待ちスレッドはグループでひとつまでにするようにしました。