### PR TITLE
スクロールするソートボタンの表示崩れの修と、アニメーション追加、カードのボタン配置変更。

### DIFF
--- a/react/src/app-components/home-components/KeepList.js
+++ b/react/src/app-components/home-components/KeepList.js
@@ -43,6 +43,7 @@ const useStyles = makeStyles((theme) => ({
     topWrapper: {
         width: '100%',
         height: '14%',
+        minHeight: '95px',
     },
     pageTitle: {
         display: 'flex',
@@ -83,8 +84,6 @@ const useStyles = makeStyles((theme) => ({
 
 const initDataList = sampleData
 
-// const initDataList = sampleData
-
 
 /*
 キープしたお店の一覧を表示するコンポーネント
@@ -108,8 +107,8 @@ function KeepList(props) {
         })
             .then(function (response) {
                 console.log(response)
-                let dataList = response['data']
-                // let dataList = initDataList
+                // let dataList = response['data']
+                let dataList = initDataList
                 if (dataList === 0) {
                     console.log("no data")
                     dataList = []
@@ -165,6 +164,7 @@ function KeepList(props) {
 
             if (event == 'sortByFavos') {
                 console.log('みんなの人気順')
+                scrollButtons(0);
                 newDataList.sort(function (a, b) {
                     // みんなの人気順でソート
                     if (+a.VotesLike > +b.VotesLike) return -1
@@ -179,6 +179,7 @@ function KeepList(props) {
                 })
             } else if (event == 'sortByHighRated') {
                 console.log('評価の高い順')
+                scrollButtons(0);
                 newDataList.sort(function (a, b) {
                     // 評価の高い順
                     if (a.ReviewRating != null) {
@@ -197,6 +198,7 @@ function KeepList(props) {
                     return 0
                 })
             } else if (event === 'sortByLowPrice') {
+                scrollButtons(80);
                 console.log('価格の安い順')
                 newDataList.sort(function (a, b) {
                     // 価格の安い順
@@ -206,6 +208,7 @@ function KeepList(props) {
                 })
             } else if (event == 'sortByRecommended') {
                 console.log('おすすめ順')
+                scrollButtons(180);
                 newDataList.sort(function (a, b) {
                     // おすすめ順
                     if (+a.RecommendScore > +b.RecommendScore) return -1
@@ -239,6 +242,35 @@ function KeepList(props) {
         } else {
             return 0
         }
+    }
+    var Ease = {
+        easeInOut: function (t) { return t<.5 ? 4*t*t*t : (t-1)*(2*t-2)*(2*t-2)+1; }
+    }
+
+    const scrollButtons = (targetPosition) => {
+        // 現在のスクロール位置を取得（クロスブラウザに対応）
+        var sortButtonWrapper = document.getElementById("sortButtonWrapper");
+        var currentPostion = sortButtonWrapper.scrollLeft;
+        // スタート時点の時間を取得
+        var startTime = performance.now();
+        // アニメーションのループを定義
+        var loop = function (nowTime) {
+            // スタートからの経過時間を取得
+            var time = nowTime - startTime;    
+            // duration を1とした場合の経過時間を計算
+            var normalizedTime = time / 500;
+            // duration に経過時間が達していない場合はアニメーションを実行
+            if (normalizedTime < 1) {
+                // 経過時間とイージングに応じてスクロール位置を変更
+                sortButtonWrapper.scrollTo(currentPostion + ((targetPosition - currentPostion) * Ease.easeInOut(normalizedTime)), 0);
+                // アニメーションを継続
+                requestAnimationFrame(loop);
+            // duration に経過時間が達したら、アニメーションを終了
+            } else {
+                sortButtonWrapper.scrollTo(targetPosition, 0);
+            }
+        }
+        requestAnimationFrame(loop);
     }
 
     const sortItems = [
@@ -286,10 +318,11 @@ function KeepList(props) {
                     <Typography className={classes.pageTitle}>
                         みんなの投票結果
                     </Typography>
-                    <div className={classes.sortButtonWrapper}>
+                    <div className={classes.sortButtonWrapper} id="sortButtonWrapper">
                         {sortItems.map((item) => (
                             <SortButton
                                 text={item.text}
+                                class={item.text}
                                 sortType={item.sortType}
                                 sortMode={sortMode}
                                 setSortMode={setSortMode}

--- a/react/src/app-components/home-components/keeplist-components/KeepListTile.js
+++ b/react/src/app-components/home-components/keeplist-components/KeepListTile.js
@@ -53,7 +53,7 @@ function KeepListTile(props) {
                             /{props.data.VotesAll}
                         </Typography>
                     </Grid>
-                    <Grid item xs={8}>
+                    <Grid item xs={12}>
                         <Grid container spacing={0}>
                             <Grid item xs={12}>
                                 <Typography class="textShopName">
@@ -82,12 +82,14 @@ function KeepListTile(props) {
                             </Grid>
                         </Grid>
                     </Grid>
-                    <Grid item xs={4}>
+                    <Grid item xs={12}>
                         <div class="buttonWrapper">
-                            <div class="buttonContainer">
-                                <div class="cardAction" onClick={() => { onInfoBtnClicked() }}>詳細を見る<span class="playIcon">▶︎</span></div>
+                            <Grid class="buttonContainer" item xs={6}>
                                 <div class="cardAction" onClick={() => { onReserveBtnClicked() }}>予約する</div>
-                            </div>
+                            </Grid>
+                            <Grid class="buttonContainer" item xs={6}>
+                                <div class="cardAction" onClick={() => { onInfoBtnClicked() }}>詳細を見る<span class="playIcon">▶︎</span></div>
+                            </Grid>
                         </div>
                     </Grid>
                 </Grid>

--- a/react/src/app-components/home-components/keeplist-components/SortButton.js
+++ b/react/src/app-components/home-components/keeplist-components/SortButton.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
         margin: "auto 6px",
         lineHeight: "30px",
         borderRadius: "30px",
-        fontSize: "13px",
+        fontSize: "16px",
         textAlign: "center",
         cursor: "pointer",
     },
@@ -28,7 +28,7 @@ const useStyles = makeStyles({
         margin: "auto 6px",
         lineHeight: "30px",
         borderRadius: "30px",
-        fontSize: "13px",
+        fontSize: "16px",
         textAlign: "center",
         cursor: "pointer",
     }

--- a/react/src/css/KeepListTile.css
+++ b/react/src/css/KeepListTile.css
@@ -7,7 +7,7 @@
 }
 .cardContent {
     padding-top: 7px;
-    padding-right: 0px;
+    padding-right: 9px;
     padding-left: 9px;
 }
 .cardContent:last-child {
@@ -47,23 +47,22 @@
     height: 100%;
     width: 100%;
     text-align: center;
-    position: relative;
 }
 .buttonContainer {
     width: 100%;
-    position: absolute;
-    bottom: 0;
+    align-items: center;
 }
 .cardAction {
     font-weight: 700;
-    font-size:0.8rem;
-    padding: 1px 2px;
-    margin: 10px auto 0;
-    width: 80%;
+    line-height: 30px;
+    font-size:16px;
+    padding: 2px 12px;
+    margin:  6px auto;
+    width: 60%;
     background-color: #D90060;
     color: #ffffff;
     border: none;
-    border-radius: 4px;
+    border-radius: 30px;
     align-items: center;
     cursor: pointer;
 }


### PR DESCRIPTION
## ソートボタンのアニメーション
タップすると画面の中央方向に移動するように変更(KeepList.js)
無限スクロールは一旦やってないです

## ソートボタンの表示崩れ
min-heightを設定することで縦方向に潰れないようにした
ブラウザごとのスクロールバー非表示は未検証

## KeepListカードのボタン配置変更
誤タップが減りそうかつ、店名の表示エリアを大きくできるような配置にした